### PR TITLE
Fix drpai layer

### DIFF
--- a/Build/start.sh
+++ b/Build/start.sh
@@ -30,11 +30,12 @@ patch -p1 < ~/RTK0EF0045Z0024AZJ-v3.0.0-update2/rzv_v300-to-v300update2.patch
 cd $WORK
 unzip ~/RTK0EF0045Z13001ZJ-v1.2_EN.zip -d ~
 tar zxvf ~/RTK0EF0045Z13001ZJ-v1.2_EN/meta-rz-features.tar.gz
-cd $WORK/meta-rz-features
-unzip ~/r11an0549ej0720-rzv2l-drpai-sp.zip
 cd $WORK
 unzip ~/RTK0EF0045Z15001ZJ-v0.58_EN.zip -d ~
 tar zxvf ~/RTK0EF0045Z15001ZJ-v0.58_EN/meta-rz-features.tar.gz
+cd $WORK
+unzip -o ~/r11an0549ej0720-rzv2l-drpai-sp.zip -d ~/r11an0549ej0720-rzv2l-drpai-sp
+tar zxvf ~/r11an0549ej0720-rzv2l-drpai-sp/rzv2l_drpai-driver/meta-rz-features.tar.gz
 cd $WORK
 source poky/oe-init-build-env
 cd $WORK/build


### PR DESCRIPTION
I noticed that **drpai** layer is not extracted properly and the recipe is not accessible.
This pull request cleans up the meta folder directories and extracts the **drpai** layer after (and on top of) the `meta-rz-feature` layer.

PS: Reading each individual commits in this PR can help with the code review.