### PR TITLE
Fix build yocto workflow

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -11,7 +11,7 @@ on:
     
 jobs:
   build-yocto:
-    runs-on: self-hosted
+    runs-on: DC02
     
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
In this pull request, I am narrowing the runner to only DC02 so it wouldn't confuse the new self-hosted runner on DC01 (used for the wiki)