### PR TITLE
Move directory permission checks inside the container

### DIFF
--- a/Build/exec.sh
+++ b/Build/exec.sh
@@ -6,6 +6,7 @@ OUTDIR=$WORK/out
 echo $hname
 len=${#hname}
 if [[ ! "$len" -eq 12 ]];
+then
     echo "ERROR: this script needs to be run inside the Yocto build container!"
     exit
 fi

--- a/Build/exec.sh
+++ b/Build/exec.sh
@@ -2,15 +2,25 @@
 set -e
 #Check hostname is a hexadecimal number of 12 
 hname=`hostname | egrep -o '^[0-9a-f]{12}\b'`
+OUTDIR=$WORK/out
 echo $hname
 len=${#hname}
-if [ "$len" -eq 12 ];
-then 
-	:
-else
+if [[ ! "$len" -eq 12 ]];
     echo "ERROR: this script needs to be run inside the Yocto build container!"
     exit
 fi
+if [[ ! -w ${OUTDIR} ]];
+then
+	echo "Unable to obtain full acess  permissions to 'output' and its sub directories, edit the permissions of 'output' accordingly! exit"
+	exit -1
+fi
+if [[ ! -w $WORK/build/sstate-cache || ! -w $WORK/build/downloads ]];
+then
+	echo "Unable to obtain write permissions to `cache` and its sub directories, edit the permissions of `cache` accordingly! exit"
+	exit -1
+fi
+
+
 ./start.sh
 if [ -z $NO ];
 then
@@ -20,12 +30,12 @@ then
 	then
 		time bitbake mistysom-image
 		echo "copying compiled images into 'out/'"
-		cp -r /home/yocto/rzv_vlp_v3.0.0/build/tmp/deploy/images/ /home/yocto/rzv_vlp_v3.0.0/out/
+		cp -r $WORK/build/tmp/deploy/images/ ${OUTDIR}
 	else
 		time sh -c "bitbake mistysom-image && bitbake mistysom-image -c populate_sdk"
 		echo "copying compiled images & SDK directories into 'out/'"
-		cp -r /home/yocto/rzv_vlp_v3.0.0/build/tmp/deploy/sdk/ /home/yocto/rzv_vlp_v3.0.0/out/
-		cp -r /home/yocto/rzv_vlp_v3.0.0/build/tmp/deploy/images/ /home/yocto/rzv_vlp_v3.0.0/out/
+		cp -r $WORK/build/tmp/deploy/sdk/ ${OUTDIR}
+		cp -r $WORK/build/tmp/deploy/images/ ${OUTDIR}
 	fi
 else
 	/bin/bash

--- a/Build/run.sh
+++ b/Build/run.sh
@@ -56,21 +56,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 CONTNAME="$(whoami)-rzv2l_vlp_v3.0.0${BRANCH}"
-if [ ! -z ${VERBOSE} ]; then
-  IGNORE_OUTPUT="2>&1 1>/dev/null"
-fi
 #Create OUTDIR if it doesn't exist
-if [ ! -d "${OUTDIR}" ];
-then
-	mkdir ${OUTDIR}
-fi
-chmod +w ${OUTDIR} ${IGNORE_OUTPUT}
-ret=$?
-if [ $ret -ne 0 ];
-then
-	echo "Unable to obtain full acess  permissions to ${OUTDIR} and its sub directories, edit the permissions of ${OUTDIR} accordingly! exit"
-	exit -1
-fi
+mkdir -p ${OUTDIR}
 if [ -z "${CPATH}" ]; 
 then
   /usr/bin/docker run --privileged ${USE_TTY} --rm -e NO=${NO} -e SDK=${SDK} -e DLOAD=${DLOAD} -v "${PWD}/${OUTDIR}":/home/yocto/rzv_vlp_v3.0.0/out --name ${CONTNAME} ${CONTNAME}
@@ -78,13 +65,5 @@ else
 	#Create CPATH sub directories if they do not exist
 	mkdir -p ${CPATH}/downloads
 	mkdir -p ${CPATH}/sstate-cache/${MPU}
-
-	chmod -R +w ${CPATH} ${IGNORE_OUTPUT}
-	ret=$?
-	if [ $ret -ne 0 ];
-	then
-		echo "Unable to obtain write permissions to ${CPATH} and its sub directories, edit the permissions of ${CPATH} accordingly! exit"
-		exit -1
-	fi
 	/usr/bin/docker run --privileged ${USE_TTY} --rm -v "${PWD}/${OUTDIR}":/home/yocto/rzv_vlp_v3.0.0/out -v "${CPATH}/downloads":/home/yocto/rzv_vlp_v3.0.0/build/downloads -v "${CPATH}/sstate-cache/${MPU}/":/home/yocto/rzv_vlp_v3.0.0/build/sstate-cache -e NO=${NO} -e SDK=${SDK} -e DLOAD=${DLOAD} --name ${CONTNAME} ${CONTNAME}
 fi


### PR DESCRIPTION
This is similar to https://github.com/MistySOM/rzg2l/pull/36

> I noticed that every time I create a new docker image, I receive an error saying that my cache directory is not writable. So I need to change the ownership of my new cache files from root to myself.
> 
> That is because the container is running as root and it creates files as root. The permission check, however, checks for the write-persmission as my user.
> 
> So to fix this, in this pull request, I am moving the permission checks from outside the container (ie. run.sh) to inside the container (ie. exec.sh)