### PR TITLE
Add wic.bz2 image output

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -29,8 +29,5 @@ jobs:
       with:
         name: output-files
         path: |
-          Build/output/images/smarc-rzv2l/Image-smarc-rzv2l.bin
-          Build/output/images/smarc-rzv2l/r9a07g054l2-smarc.dtb
-          Build/output/images/smarc-rzv2l/r9a07g054l2-smarc-ar0234.dtb
-          Build/output/images/smarc-rzv2l/r9a07g054l2-smarc-imx462.dtb
-          Build/output/images/smarc-rzv2l/mistysom-image-smarc-rzv2l.tar.bz2
+          Build/output/images/smarc-rzv2l/mistysom-image-smarc-rzv2l.wic.bz2
+          Build/output/images/smarc-rzv2l/mistysom-image-smarc-rzv2l.ext4.bz2

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -21,13 +21,11 @@ jobs:
     - name: Build the Docker image
       run: cd Build && ./build.sh; 
     
-    - name: Run the Docker image and build output files with SDK
+    - name: Run the Docker image and build output files
       run: cd Build && ./run.sh -c /home/github/rzv2l-cache;
       
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: output-files
-        path: |
-          Build/output/images/smarc-rzv2l/mistysom-image-smarc-rzv2l.wic.bz2
-          Build/output/images/smarc-rzv2l/mistysom-image-smarc-rzv2l.ext4.bz2
+        name: output-image
+        path: Build/output/images/smarc-rzv2l/mistysom-image-smarc-rzv2l.wic.bz2


### PR DESCRIPTION
In this pull request, I am changing the image deploy output to wic.bz2

The reason behind the bz2 additional extension is that the file sizes go beyond 900 MB which is not suitable for download and upload.

The wic.bz2 file can be written into an SD card with the command below which creates two partitions for boot and root:
```
pv mistysom-image-smarc-rzv2l.wic.bz2 | bzcat | sudo dd bs=4M of=/dev/sdX
```