### PR TITLE
Adjust the parallel settings

### DIFF
--- a/Build/start.sh
+++ b/Build/start.sh
@@ -34,12 +34,10 @@ echo "IMAGE_INSTALL_append = \" gstreamer1.0-drpai ai-eva-sw\"" >> ${WORK}/meta-
 #echo "applying drpai patch"
 #patch -p2 < ../rzv2l-drpai-conf.patch
 #echo "drpai patch applied"
-swp=`cat /proc/meminfo | grep "SwapTotal"|awk '{print $2}'`
-mem=`cat /proc/meminfo | grep "MemTotal"|awk '{print $2}'`
-NUM_CPU=$(((mem+swp)/1000/1000/4))
-#NUM_CPU=`nproc`
-##Update number of CPUs in local.conf
-sed -i "1 i\PARALLEL_MAKE = \"-j ${NUM_CPU}\"\nBB_NUMBER_THREADS = \"${NUM_CPU}\"" ${LOCALCONF}
+
+## Update number of CPUs in local.conf
+(NUM_CPU=$(nproc) && echo "BB_NUMBER_THREADS = \"$((NUM_CPU*2))\"" >> ${LOCALCONF}) || :
+
 # Comment out the line that flags GPLv3 as an incompatible license
 sed -i '/^INCOMPATIBLE_LICENSE = \"GPLv3 GPLv3+\"/ s/./#&/' ${LOCALCONF}
 # append hostname to local.conf


### PR DESCRIPTION
This is similar to https://github.com/MistySOM/rzg2l/pull/37

> In this pull request, I am changing the CPU_NUM value back to nproc command which results the correct value of '4' in DC02, instead of the incorrect '12'
> 
> According to bitbake documentation [here](https://docs.yoctoproject.org/bitbake/2.4/bitbake-user-manual/bitbake-user-manual-ref-variables.html#term-BB_NUMBER_THREADS):
> 
> The maximum number of tasks BitBake should run in parallel at any one time. If your host development system supports multiple cores, a good rule of thumb is to set this variable to twice the number of cores.
> 
> Therefore, I am multiplying CPU_NUM by 2 for BB_NUMBER_THREADS.
> 
> However, for PARALLEL_MAKE and every other parallel setting, the documentation says they all default to the number of cores. So no need to override them.
> 
> The Good:
> This will cause the bitbake command with cache to complete around 10% faster.
> This will cause running multiple bitbake runs to add less pressure on the server.