### PR TITLE
Bootloader file cleanup

### DIFF
--- a/Build/exec.sh
+++ b/Build/exec.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-board="rzv2l"
-som="SOMV2L"
+#Use lower case to specify the CPU type ("v2l" or "g2l")
+TYPE="v2l"
 set -e
 #Check hostname is a hexadecimal number of 12 
 hname=`hostname | egrep -o '^[0-9a-f]{12}\b'`
@@ -45,9 +45,9 @@ then
 	rm bl*
 	m fip*
 	rm Flash_Writer*
-	wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/Flash_Writer_SCIF_${board^^}.mot
-	wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/bl2_bp-Misty${som}.srec
-	wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/fip-Misty${som}.srec
+	wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/Flash_Writer_SCIF_rz${TYPE}.mot
+	wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/bl2_bp-MistySOM${TYPE^^}.srec
+	wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/fip-MistySOM${TYPE^^}.srec
 else
 	/bin/bash
 fi

--- a/Build/exec.sh
+++ b/Build/exec.sh
@@ -7,6 +7,9 @@ hname=`hostname | egrep -o '^[0-9a-f]{12}\b'`
 OUTDIR=$WORK/out
 echo $hname
 len=${#hname}
+FLW_FILE_URL="https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/Flash_Writer_SCIF_RZV2L.mot"
+BL2_FILE_URL="https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/bl2_bp-MistySOMV2L.srec"
+FIP_FILE_URL="https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/fip-MistySOMV2L.srec"
 if [[ ! "$len" -eq 12 ]];
 then
     echo "ERROR: this script needs to be run inside the Yocto build container!"
@@ -45,9 +48,9 @@ then
 	rm bl*
 	rm fip*
 	rm Flash_Writer*
-	wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/Flash_Writer_SCIF_rz${TYPE}.mot
-	wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/bl2_bp-MistySOM${TYPE^^}.srec
-	wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/fip-MistySOM${TYPE^^}.srec
+	wget ${FLW_FILE_URL}
+	wget ${BL2_FILE_URL}
+	wget ${FIP_FILE_URL}
 else
 	/bin/bash
 fi

--- a/Build/exec.sh
+++ b/Build/exec.sh
@@ -32,11 +32,21 @@ then
 		time bitbake mistysom-image
 		echo "copying compiled images into 'out/'"
 		cp -r $WORK/build/tmp/deploy/images/ ${OUTDIR}
+		cd ${OUTDIR}
+		rm smarc-rzv2l/bl2*
+		rm smarc-rzv2l/fip*
+		wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/bl2_bp-MistySOMV2L.srec
+		wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/fip-MistySOMV2L.srec
 	else
 		time sh -c "bitbake mistysom-image && bitbake mistysom-image -c populate_sdk"
 		echo "copying compiled images & SDK directories into 'out/'"
 		cp -r $WORK/build/tmp/deploy/sdk/ ${OUTDIR}
 		cp -r $WORK/build/tmp/deploy/images/ ${OUTDIR}
+		cd ${OUTDIR}
+		rm smarc-rzv2l/bl2*
+		rm smarc-rzv2l/fip*
+		wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/bl2_bp-MistySOMV2L.srec
+		wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/fip-MistySOMV2L.srec
 	fi
 else
 	/bin/bash

--- a/Build/exec.sh
+++ b/Build/exec.sh
@@ -43,7 +43,7 @@ then
  	#manually fiup bootloader files in directory
  	cd ${OUTDIR}/images/smarc-${board}
 	rm bl*
-	m fip*
+	rm fip*
 	rm Flash_Writer*
 	wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/Flash_Writer_SCIF_rz${TYPE}.mot
 	wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/bl2_bp-MistySOM${TYPE^^}.srec

--- a/Build/exec.sh
+++ b/Build/exec.sh
@@ -32,9 +32,11 @@ then
 		time bitbake mistysom-image
 		echo "copying compiled images into 'out/'"
 		cp -r $WORK/build/tmp/deploy/images/ ${OUTDIR}
-		cd ${OUTDIR}
-		rm smarc-rzv2l/bl2*
-		rm smarc-rzv2l/fip*
+		cd ${OUTDIR}/images/smarc-rzv2l
+		rm bl*
+		rm fip*
+		rm Flash_Writer*
+		wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/Flash_Writer_SCIF_RZV2L.mot
 		wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/bl2_bp-MistySOMV2L.srec
 		wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/fip-MistySOMV2L.srec
 	else

--- a/Build/exec.sh
+++ b/Build/exec.sh
@@ -41,7 +41,7 @@ then
 		cp -r $WORK/build/tmp/deploy/images/ ${OUTDIR}
 	fi
  	#manually fiup bootloader files in directory
- 	cd ${OUTDIR}/images/smarc-${board}
+ 	cd ${OUTDIR}/images/smarc-rz${TYPE}
 	rm bl*
 	rm fip*
 	rm Flash_Writer*

--- a/Build/exec.sh
+++ b/Build/exec.sh
@@ -48,9 +48,9 @@ then
 	rm bl*
 	rm fip*
 	rm Flash_Writer*
-	wget ${FLW_FILE_URL}
 	wget ${BL2_FILE_URL}
 	wget ${FIP_FILE_URL}
+	wget ${FLW_FILE_URL}
 else
 	/bin/bash
 fi

--- a/Build/exec.sh
+++ b/Build/exec.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+board="rzv2l"
+som="SOMV2L"
 set -e
 #Check hostname is a hexadecimal number of 12 
 hname=`hostname | egrep -o '^[0-9a-f]{12}\b'`
@@ -32,24 +34,20 @@ then
 		time bitbake mistysom-image
 		echo "copying compiled images into 'out/'"
 		cp -r $WORK/build/tmp/deploy/images/ ${OUTDIR}
-		cd ${OUTDIR}/images/smarc-rzv2l
-		rm bl*
-		rm fip*
-		rm Flash_Writer*
-		wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/Flash_Writer_SCIF_RZV2L.mot
-		wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/bl2_bp-MistySOMV2L.srec
-		wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/fip-MistySOMV2L.srec
 	else
 		time sh -c "bitbake mistysom-image && bitbake mistysom-image -c populate_sdk"
 		echo "copying compiled images & SDK directories into 'out/'"
 		cp -r $WORK/build/tmp/deploy/sdk/ ${OUTDIR}
 		cp -r $WORK/build/tmp/deploy/images/ ${OUTDIR}
-		cd ${OUTDIR}
-		rm smarc-rzv2l/bl2*
-		rm smarc-rzv2l/fip*
-		wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/bl2_bp-MistySOMV2L.srec
-		wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/fip-MistySOMV2L.srec
 	fi
+ 	#manually fiup bootloader files in directory
+ 	cd ${OUTDIR}/images/smarc-${board}
+	rm bl*
+	m fip*
+	rm Flash_Writer*
+	wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/Flash_Writer_SCIF_${board^^}.mot
+	wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/bl2_bp-Misty${som}.srec
+	wget https://github.com/MistySOM/wiki/blob/master/files/bootloader/rzv2l/fip-Misty${som}.srec
 else
 	/bin/bash
 fi


### PR DESCRIPTION
Replace compiled Flash Writer & bootloaders with the ones downloaded from GitHub (linked on the wiki [page](https://github.com/MistySOM/wiki/blob/master/content/BoardStartUpGuide.md)). I'm not sure yet if this is the right thing todo. It's a temporary patch that will avoidthe same issue that Brennan had to do from repeating. I'll leave this as a draft to get @matinlotfali  's input on this as well! 