### PR TITLE
Update build-yocto.yml to fix the including and excluding path

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -3,12 +3,10 @@ name: Build Yocto Image
 on:
   push:
     branches: [ "master", "develop", "Projects/**" ]
-    paths-ignore: [ '**.md', '**.pdf', '**.yml' ]
-    paths: [ "Build/**" ]
+    paths: [ "Build/**", '!**.md', '!**.pdf', '!**.yml' ]
   pull_request:
     branches: [ "master", "develop", "Projects/**" ]
-    paths-ignore: [ '**.md', '**.pdf', '**.yml' ]
-    paths: [ "Build/**" ]
+    paths: [ "Build/**", '!**.md', '!**.pdf', '!**.yml' ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/check-submodule.yml
+++ b/.github/workflows/check-submodule.yml
@@ -3,12 +3,10 @@ name: Check meta-mistysom Submodule
 on:
   push:
     branches: [ "master", "develop", "Projects/**" ]
-    paths-ignore: [ '**.md', '**.pdf', '**.yml' ]
-    paths: [ "Build/**" ]
+    paths: [ "Build/**", '!**.md', '!**.pdf', '!**.yml' ]
   pull_request:
     branches: [ "master", "develop", "Projects/**" ]
-    paths-ignore: [ '**.md', '**.pdf', '**.yml' ]
-    paths: [ "Build/**" ]
+    paths: [ "Build/**", '!**.md', '!**.pdf', '!**.yml' ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This is related to here: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths

This got broken in #75 